### PR TITLE
report_unknown option output moved to info log level

### DIFF
--- a/custom_components/mitemp_bt/sensor.py
+++ b/custom_components/mitemp_bt/sensor.py
@@ -232,7 +232,7 @@ def parse_raw_message(data, aeskeyslist, report_unknown=False):
         ]
     except KeyError:
         if report_unknown:
-            _LOGGER.debug(
+            _LOGGER.info(
                 "BLE ADV from UNKNOWN: RSSI: %s, MAC: %s, ADV: %s",
                 rssi,
                 ''.join('{:02X}'.format(x) for x in xiaomi_mac_reversed[::-1]),
@@ -391,7 +391,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     scanner.start(config)
     sensors_by_mac = {}
     if config[CONF_REPORT_UNKNOWN]:
-        _LOGGER.debug(
+        _LOGGER.info(
             "Attention! Option report_unknown is enabled, be ready for a huge output..."
         )
     # prepare device:key list to speedup parser

--- a/faq.md
+++ b/faq.md
@@ -152,20 +152,20 @@ Most often, the cause of this is the presence of bugs in the system components r
 ### My sensor from the Xiaomi ecosystem is not in the list of supported ones. How to request implementation?
 
 - [Install the component](https://github.com/custom-components/sensor.mitemp_bt/blob/master/README.md#how-to-install) if you have not already done so.
-- Make sure you have [logger](https://www.home-assistant.io/integrations/logger/) enabled, and logging enabled for `debug` level (globally or just for `custom_components.mitemp_bt`). For example:
+- Make sure you have [logger](https://www.home-assistant.io/integrations/logger/) enabled, and logging enabled for `info` level (globally or just for `custom_components.mitemp_bt`). For example:
 
 ```yaml
 logger:
   default: warn
   logs:
-    custom_components.mitemp_bt: debug
+    custom_components.mitemp_bt: info
 ```
 
 - Place your sensor extremely close to the HA host (BT interface).
 - [Enable the option](https://github.com/custom-components/sensor.mitemp_bt/blob/master/README.md#configuration) `report_unknown`.
 - Wait until a number of "BLE ADV from UNKNOWN" messages accumulate in the log.
 - Create a new [issue](https://github.com/custom-components/sensor.mitemp_bt/issues), write everything you know about your sensor and attach the obtained log.
-- Do not forget to disable the `report_unknown` option (delete it or set it to `False` and restart HA).
+- Do not forget to disable the `report_unknown` option (delete it or set it to `False` and restart HA)! Since the potentially large output of this option will spam the log and can mask really important messages.
 - Wait for a response from the developers.
 
 ## DEBUG


### PR DESCRIPTION
[I asked for clarification](https://github.com/home-assistant/developers.home-assistant/issues/428) about what is stated in Style guidelines.

I insist that that the output of the report_unknown option should be at the info level. I have a few arguments:
1. This output is not directly related to debugging.
2. The user can be interested in it.
3. This output must be enabled (disabled by default, the user makes the decision).