### PR TITLE
Remove HASSio from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This custom component is an alternative for the standard build in [mitemp_bt](ht
 
 ## HOW TO INSTALL
 
-**1. Grant permissions for Python rootless access to HCI interface (usually not needed on HASSio):**
+**1. Grant permissions for Python rootless access to HCI interface (usually only needed for alternative installations of home assistant core):**
 
 - to grant:
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This custom component is an alternative for the standard build in [mitemp_bt](ht
 
 ## HOW TO INSTALL
 
-**1. Grant permissions for Python rootless access to HCI interface (usually only needed for alternative installations of home assistant core):**
+**1. Grant permissions for Python rootless access to HCI interface (usually only needed for alternative installations of home assistant that only install home assistant core):**
 
 - to grant:
 

--- a/faq.md
+++ b/faq.md
@@ -61,7 +61,7 @@ The command will return the path to python and looks like (can vary based on you
 /usr/bin/python3.7 = cap_net_admin,cap_net_raw+eip
 ```
 
-Make sure you first stop homeassistant and then start homeassistant again. Restarting Home Assistant is not enough, as the python process does not exit upon restart.
+Make sure you first stop Home Assistant and then start Home Assistant again. Restarting Home Assistant is not enough, as the python process does not exit upon restart.
 
 If you have multiple python versions, make sure it refers to the same version which is used by Home Assistant. If Home Assistant is using a different version, e.g. python3.6, run the following command to set the correct version (adjust it to your own version if needed).
 

--- a/info.md
+++ b/info.md
@@ -114,7 +114,7 @@ This custom component is an alternative for the standard build in [mitemp_bt](ht
 
 ## HOW TO INSTALL
 
-**1. Grant permissions for Python rootless access to HCI interface (usually not needed on HASSio):**
+**1. Grant permissions for Python rootless access to HCI interface (usually only needed for alternative installations of home assistant that only install home assistant core):**
 
 - to grant:
 


### PR DESCRIPTION
Small change in docs, as the name HASSio no longer used and is changed to home assistant (and home assistant to home assistant core).

