### PR TITLE
Handle AssertionError when HA is still in startup

### DIFF
--- a/custom_components/mitemp_bt/sensor.py
+++ b/custom_components/mitemp_bt/sensor.py
@@ -498,7 +498,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             getattr(entity_to_update, "_device_state_attributes")["mean"] = state_mean
             entity_to_update.schedule_update_ha_state()
             success = True
-        except AttributeError:
+        except (AttributeError, AssertionError):
             _LOGGER.debug("Sensor %s not yet ready for update", sensor_mac)
             success = True
         except ZeroDivisionError as err:


### PR DESCRIPTION
Fixes #93.

When HA is still in startup, and we schedule a state update, it may fail with the following exception:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/mitemp_bt/sensor.py", line 775, in update_ble
    discover_ble_devices(config, aeskeys, whitelist)
  File "/config/custom_components/mitemp_bt/sensor.py", line 683, in discover_ble_devices
    sensors[t_i], mac, config, temp_m_data[mac]
  File "/config/custom_components/mitemp_bt/sensor.py", line 499, in calc_update_state
    entity_to_update.schedule_update_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 416, in schedule_update_ha_state
    assert self.hass is not None
```

This change simply adds `AssertionError` to the already-handled `AttributeError`, so we retry later.