### PR TITLE
Change a debug message to info

### DIFF
--- a/custom_components/mitemp_bt/sensor.py
+++ b/custom_components/mitemp_bt/sensor.py
@@ -760,7 +760,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                         "Sensor %s (%s, switch) update error:", mac, stype[mac]
                     )
                     _LOGGER.error(err)
-        _LOGGER.debug(
+        _LOGGER.info(
             "Finished. Parsed: %i hci events, %i xiaomi devices.",
             len(hcidump_raw),
             len(macs),


### PR DESCRIPTION
It would be really useful to have the final message on the success of the scanning.

Even better would be a sensor with this info.