### PR TITLE
Add new sensor: MHO-C401

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ This custom component is an alternative for the standard build in [mitemp_bt](ht
 - WX08ZM
 
   (Xiaomi Mija Mosquito Repellent, Smart version, broadcasts switch state, tablet resource, battery level, about 50 messages per minute)
+  
+- MHO-C401
+  
+  (small square body, E-Ink display, broadcasts temperature and humidity once in about 10 minutes and battery level once in an hour, advertisements are encrypted, therefore you need to set the key in your configuration, see for instructions the [encryptors](#configuration-variables) option)
 
 *The amount of actually received data is highly dependent on the reception conditions (like distance and electromagnetic ambiance), readings numbers are indicated for good RSSI (Received Signal Strength Indicator) of about -75 till -70dBm.*
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
 
 #### encryptors
 
-   (dictionary)(Optional) This option is used to link the mac-address of the sensor broadcasting encrypted advertisements to the encryption key (32 characters = 16 bytes). This is only needed for LYWSD03MMC and CGD1 sensors. The case of the characters does not matter. The keys below are an example, you need your own key(s)! Information on how to get your key(s) can be found [here](https://github.com/custom-components/sensor.mitemp_bt/blob/master/faq.md#my-sensors-ble-advertisements-are-encrypted-how-can-i-get-the-key). Default value: Empty
+   (dictionary)(Optional) This option is used to link the mac-address of the sensor broadcasting encrypted advertisements to the encryption key (32 characters = 16 bytes). This is only needed for LYWSD03MMC, CGD1 and MHO-C401 sensors. The case of the characters does not matter. The keys below are an example, you need your own key(s)! Information on how to get your key(s) can be found [here](https://github.com/custom-components/sensor.mitemp_bt/blob/master/faq.md#my-sensors-ble-advertisements-are-encrypted-how-can-i-get-the-key). Default value: Empty
 
    ```yaml
    sensor:

--- a/custom_components/mitemp_bt/const.py
+++ b/custom_components/mitemp_bt/const.py
@@ -48,7 +48,8 @@ XIAOMI_TYPE_DICT = {
     b'\x5B\x05': "LYWSD03MMC",
     b'\x76\x05': "CGD1",
     b'\xDF\x02': "JQJCY01YM",
-    b'\x0A\x04': "WX08ZM"
+    b'\x0A\x04': "WX08ZM",
+    b'\x87\x03': "MHO-C401"
 }
 
 
@@ -65,7 +66,8 @@ MMTS_DICT = {
     'LYWSD03MMC': [0, 1, 9, 9, 9, 9, 9, 9, 2],
     'CGD1'      : [0, 1, 9, 9, 9, 9, 9, 9, 2],
     'JQJCY01YM' : [0, 1, 9, 9, 9, 2, 9, 9, 3],
-    'WX08ZM'    : [9, 9, 9, 9, 9, 9, 0, 1, 2]
+    'WX08ZM'    : [9, 9, 9, 9, 9, 9, 0, 1, 2],
+    'MHO-C401'  : [0, 1, 9, 9, 9, 9, 9, 9, 2]
 }
 
 # Switch binary sensor classes dict

--- a/custom_components/mitemp_bt/sensor.py
+++ b/custom_components/mitemp_bt/sensor.py
@@ -467,8 +467,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         # formaldehyde decimals workaround
         if fdec > 0:
             rdecimals = fdec
-        # LYWSD03MMC "jagged" humidity workaround
-        if stype == "LYWSD03MMC":
+        # LYWSD03MMC / MHO-C401 "jagged" humidity workaround
+        if stype == "LYWSD03MMC" or stype == "MHO-C401":
             measurements = [int(item) for item in measurements_list]
         else:
             measurements = measurements_list


### PR DESCRIPTION
![MHO-C401](https://ae01.alicdn.com/kf/H1d1fa6e8e599418ba73d411b8fe099e29/2020-New-Xiaomi-MMC-E-Ink-Screen-Smart-Bluetooth-Thermometer-Hygrometer-BT2-0-Temperature-Humidity-Sensor.png_640x640.png)

There is a new version of a nice square E-Ink temperature and humidity sensor, which now supports Bluetooth. This new sensor is listed as **_MHO-C401 (2020 version)_** [here](https://www.aliexpress.com/item/4001174769598.html).

Its Bluetooth operations are quite similar to those of LYWSD03MMC - i.e. it broadcasts temperature and humidity once in about 10 minutes and battery level once in an hour, and advertisements are encrypted.

I've added this new device (its XIAOMI_TYPE bytes are 0x8703) to the dictionaries in const.py. Then I just had to extract the `bind_key` from the modified Xiaomi Home App in order to supply it to the `encryptors` configuration, and the new sensor appeared in my Home Assistance instance.

Probably the only thing that needs to be modified (code-wise) is the sensors.jpg image, in order to include a picture of the new sensor.

Hope you'll find this Pull Request useful.


Cheers,
zn