### PR TITLE
Sensor names option

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ sensor:
     batt_entities: False
     encryptors:
       'A4:C1:38:2F:86:6C': '217C568CF5D22808DA20181502D84C1B'
+    custom_names:
+      'A4:C1:38:2F:86:6C': 'Livingroom'
     report_unknown: False
     whitelist: False
 ```
@@ -230,6 +232,18 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
          'A4:C1:38:D1:61:7D': 'C99D2313182473B38001086FEBF781BD'
    ```
 
+#### custom_names
+
+   (dictionary)(Optional) Use this option to link a sensor name to the mac-address of the sensor. This sensor name will be used as default name in the UI of Home Assistant (e.g. Temperature Livingroom). If no sensor name is provided for a given mac-address, the mac-address will be used in the UI (e.g. Temperature A4C1382F866C). Default value: Empty
+
+   ```yaml
+   sensor:
+     - platform: mitemp_bt
+       custom_names:
+         'A4:C1:38:2F:86:6C': 'Livingroom'
+         'A4:C1:38:D1:61:7D': 'Bedroom'
+   ```
+
 #### report_unknown
 
    (boolean)(Optional) This option is needed primarily for those who want to request an implementation of device support that is not in the list of [supported sensors](#supported-sensors). If you set this parameter to `True`, then the component will log all messages from unknown Xiaomi ecosystem devices to the Home Assitant log. **Attention!** Enabling this option can lead to huge output to the Home Assistant log, do not enable it if you do not need it! Details in the [FAQ](https://github.com/custom-components/sensor.mitemp_bt/blob/master/faq.md#my-sensor-from-the-xiaomi-ecosystem-is-not-in-the-list-of-supported-ones-how-to-request-implementation). Default value: False
@@ -247,8 +261,8 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
    ```
 
    Data from sensors with other addresses will be ignored.
-   In addition, all addresses listed in the `encryptors` option will be automatically whitelisted.
-   If you have no sensors other than those listed in `encryptors`, then just set `whitelist` to `True`:
+   In addition, all addresses listed in the `encryptors` and `custom_names` option will be automatically whitelisted.
+   If you have no sensors other than those listed in `encryptors` and `custom_names`, then just set `whitelist` to `True`:
 
    ```yaml
    sensor:

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
 
 #### sensor_names
 
-   (dictionary)(Optional) Use this option to link a sensor name to the mac-address of the sensor. This sensor name will be used as default name in the UI of Home Assistant (e.g. Temperature Livingroom). If no sensor name is provided for a given mac-address, the mac-address will be used in the UI (e.g. Temperature A4C1382F866C). Default value: Empty
+   (dictionary)(Optional) Use this option to link a sensor name to the mac-address of the sensor. Using this option (or changing a name) will create new entities after restarting Home Assistant. These sensors are named with the following convention: sensor.mi_sensortype_sensor_name (e.g. sensor.mi_temperature_livingroom) in stead of the default mi_sensortype_mac (e.g. sensor.mi_temperature_A4C1382F86C). Note that you will have to manually delete the old entities from the Developer Tools section and the old data won't be transfered to the new sensor. Also note that you can still override the entity_id from the UI. Default value: Empty
 
    ```yaml
    sensor:
@@ -262,7 +262,7 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
 
    Data from sensors with other addresses will be ignored.
    In addition, all addresses listed in the `encryptors` and `sensor_names` option will be automatically whitelisted.
-   If you have no sensors other than those listed in `encryptors` and `sensor_names`, then just set `whitelist` to `True`:
+   If you have no sensors other than those listed in `encryptors` and/or `sensor_names`, then just set `whitelist` to `True`:
 
    ```yaml
    sensor:

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ sensor:
     batt_entities: False
     encryptors:
       'A4:C1:38:2F:86:6C': '217C568CF5D22808DA20181502D84C1B'
-    custom_names:
+    sensor_names:
       'A4:C1:38:2F:86:6C': 'Livingroom'
     report_unknown: False
     whitelist: False
@@ -232,14 +232,14 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
          'A4:C1:38:D1:61:7D': 'C99D2313182473B38001086FEBF781BD'
    ```
 
-#### custom_names
+#### sensor_names
 
    (dictionary)(Optional) Use this option to link a sensor name to the mac-address of the sensor. This sensor name will be used as default name in the UI of Home Assistant (e.g. Temperature Livingroom). If no sensor name is provided for a given mac-address, the mac-address will be used in the UI (e.g. Temperature A4C1382F866C). Default value: Empty
 
    ```yaml
    sensor:
      - platform: mitemp_bt
-       custom_names:
+       sensor_names:
          'A4:C1:38:2F:86:6C': 'Livingroom'
          'A4:C1:38:D1:61:7D': 'Bedroom'
    ```
@@ -261,8 +261,8 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
    ```
 
    Data from sensors with other addresses will be ignored.
-   In addition, all addresses listed in the `encryptors` and `custom_names` option will be automatically whitelisted.
-   If you have no sensors other than those listed in `encryptors` and `custom_names`, then just set `whitelist` to `True`:
+   In addition, all addresses listed in the `encryptors` and `sensor_names` option will be automatically whitelisted.
+   If you have no sensors other than those listed in `encryptors` and `sensor_names`, then just set `whitelist` to `True`:
 
    ```yaml
    sensor:

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
 
 #### sensor_names
 
-   (dictionary)(Optional) Use this option to link a sensor name to the mac-address of the sensor. Using this option (or changing a name) will create new entities after restarting Home Assistant. These sensors are named with the following convention: sensor.mi_sensortype_sensor_name (e.g. sensor.mi_temperature_livingroom) in stead of the default mi_sensortype_mac (e.g. sensor.mi_temperature_A4C1382F86C). Note that you will have to manually delete the old entities from the Developer Tools section and the old data won't be transfered to the new sensor. Also note that you can still override the entity_id from the UI. Default value: Empty
+   (dictionary)(Optional) Use this option to link a sensor name to the mac-address of the sensor. Using this option (or changing a name) will create new entities after restarting Home Assistant. These sensors are named with the following convention: `sensor.mi_sensortype_sensor_name` (e.g. `sensor.mi_temperature_livingroom`) in stead of the default `mi_sensortype_mac` (e.g. `sensor.mi_temperature_A4C1382F86C`). You will have to update your lovelace cards, automation and scripts after each change. Note that you can still override the entity_id from the UI. After the change, you can manually delete the old entities from the Developer Tools section. The old data won't be transfered to the new sensor. Default value: Empty
 
    ```yaml
    sensor:

--- a/custom_components/mitemp_bt/const.py
+++ b/custom_components/mitemp_bt/const.py
@@ -15,6 +15,7 @@ CONF_BATT_ENTITIES = "batt_entities"
 CONF_ENCRYPTORS = "encryptors"
 CONF_REPORT_UNKNOWN = "report_unknown"
 CONF_WHITELIST = "whitelist"
+CONF_CUSTOM_NAMES = "custom_names"
 
 # Default values for configuration options
 DEFAULT_ROUNDING = True

--- a/custom_components/mitemp_bt/const.py
+++ b/custom_components/mitemp_bt/const.py
@@ -15,7 +15,7 @@ CONF_BATT_ENTITIES = "batt_entities"
 CONF_ENCRYPTORS = "encryptors"
 CONF_REPORT_UNKNOWN = "report_unknown"
 CONF_WHITELIST = "whitelist"
-CONF_CUSTOM_NAMES = "custom_names"
+CONF_SENSOR_NAMES = "sensor_names"
 
 # Default values for configuration options
 DEFAULT_ROUNDING = True

--- a/custom_components/mitemp_bt/sensor.py
+++ b/custom_components/mitemp_bt/sensor.py
@@ -683,6 +683,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     sts.mean(rssi[mac])
                 )
                 getattr(sensor, "_device_state_attributes")["sensor type"] = stype[mac]
+                getattr(sensor, "_device_state_attributes")["mac address"] = (
+                    ':'.join(mac[i:i+2] for i in range(0, len(mac), 2))
+                    )
                 if not isinstance(sensor, BatterySensor) and mac in batt:
                     getattr(sensor, "_device_state_attributes")[
                         ATTR_BATTERY_LEVEL
@@ -818,13 +821,13 @@ class TemperatureSensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "t_" + mac
+        self._unique_id = "t_" + sensor_name(config, mac)
         self._device_state_attributes = {}
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "Temperature {}".format(self._sensor_name)
+        return "mi temperature {}".format(self._sensor_name)
 
     @property
     def state(self):
@@ -870,13 +873,13 @@ class HumiditySensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "h_" + mac
+        self._unique_id = "h_" + sensor_name(config, mac)
         self._device_state_attributes = {}
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "Humidity {}".format(self._sensor_name)
+        return "mi humidity {}".format(self._sensor_name)
 
     @property
     def state(self):
@@ -922,13 +925,13 @@ class MoistureSensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "m_" + mac
+        self._unique_id = "m_" + sensor_name(config, mac)
         self._device_state_attributes = {}
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "Moisture {}".format(self._sensor_name)
+        return "mi moisture {}".format(self._sensor_name)
 
     @property
     def state(self):
@@ -974,13 +977,13 @@ class ConductivitySensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "c_" + mac
+        self._unique_id = "c_" + sensor_name(config, mac)
         self._device_state_attributes = {}
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "Conductivity {}".format(self._sensor_name)
+        return "mi conductivity {}".format(self._sensor_name)
 
     @property
     def state(self):
@@ -1026,13 +1029,13 @@ class IlluminanceSensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "l_" + mac
+        self._unique_id = "l_" + sensor_name(config, mac)
         self._device_state_attributes = {}
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "Illuminance {}".format(self._sensor_name)
+        return "mi llluminance {}".format(self._sensor_name)
 
     @property
     def state(self):
@@ -1077,13 +1080,13 @@ class FormaldehydeSensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "f_" + mac
+        self._unique_id = "f_" + sensor_name(config, mac)
         self._device_state_attributes = {}
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "Formaldehyde {}".format(self._sensor_name)
+        return "mi formaldehyde {}".format(self._sensor_name)
 
     @property
     def state(self):
@@ -1127,13 +1130,13 @@ class BatterySensor(Entity):
         """Initialize the sensor."""
         self._state = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "batt_" + mac
+        self._unique_id = "batt_" + sensor_name(config, mac)
         self._device_state_attributes = {}
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "Battery {}".format(self._sensor_name)
+        return "mi battery {}".format(self._sensor_name)
 
     @property
     def state(self):
@@ -1178,13 +1181,13 @@ class ConsumableSensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "cn_" + mac
+        self._unique_id = "cn_" + sensor_name(config, mac)
         self._device_state_attributes = {}
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "Consumable {}".format(self._sensor_name)
+        return "mi consumable {}".format(self._sensor_name)
 
     @property
     def state(self):
@@ -1230,7 +1233,7 @@ class SwitchBinarySensor(BinarySensorEntity):
         self._swclass = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "sw_" + mac
+        self._unique_id = "sw_" + sensor_name(config, mac)
         self._device_state_attributes = {}
 
     @property
@@ -1241,7 +1244,7 @@ class SwitchBinarySensor(BinarySensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return "Switch {}".format(self._sensor_name)
+        return "mi switch {}".format(self._sensor_name)
 
     @property
     def state(self):

--- a/custom_components/mitemp_bt/sensor.py
+++ b/custom_components/mitemp_bt/sensor.py
@@ -54,7 +54,7 @@ from .const import (
     CONF_ENCRYPTORS,
     CONF_REPORT_UNKNOWN,
     CONF_WHITELIST,
-    CONF_CUSTOM_NAMES,
+    CONF_SENSOR_NAMES,
     CONF_TMIN,
     CONF_TMAX,
     CONF_HMIN,
@@ -71,7 +71,7 @@ _LOGGER = logging.getLogger(__name__)
 MAC_REGEX = "(?i)^(?:[0-9A-F]{2}[:]){5}(?:[0-9A-F]{2})$"
 AES128KEY_REGEX = "(?i)^[A-F0-9]{32}$"
 
-CUSTOM_NAMES_LIST_SCHEMA = vol.Schema(
+SENSOR_NAMES_LIST_SCHEMA = vol.Schema(
     {
         cv.matches_regex(MAC_REGEX): cv.string
     }
@@ -100,7 +100,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(
             CONF_WHITELIST, default=DEFAULT_WHITELIST
         ): vol.Any(vol.All(cv.ensure_list, [cv.matches_regex(MAC_REGEX)]), cv.boolean),
-        vol.Optional(CONF_CUSTOM_NAMES, default={}): CUSTOM_NAMES_LIST_SCHEMA,
+        vol.Optional(CONF_SENSOR_NAMES, default={}): SENSOR_NAMES_LIST_SCHEMA,
     }
 )
 
@@ -374,8 +374,8 @@ def parse_raw_message(data, aeskeyslist,  whitelist, report_unknown=False):
 def sensor_name(config, mac):
     """Set sensor name."""
     fmac = ':'.join(mac[i:i+2] for i in range(0, len(mac), 2))
-    if fmac in config[CONF_CUSTOM_NAMES]:
-        custom_name = config[CONF_CUSTOM_NAMES].get(fmac)
+    if fmac in config[CONF_SENSOR_NAMES]:
+        custom_name = config[CONF_SENSOR_NAMES].get(fmac)
         _LOGGER.debug("Name of sensor with mac adress %s is set to: %s", fmac, custom_name)
         return custom_name
     return mac
@@ -468,14 +468,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if config[CONF_WHITELIST] is True:
             for mac in config[CONF_ENCRYPTORS]:
                 whitelist.append(mac)
-            for mac in config[CONF_CUSTOM_NAMES]:
+            for mac in config[CONF_SENSOR_NAMES]:
                 whitelist.append(mac)
     if isinstance(config[CONF_WHITELIST], list):
         for mac in config[CONF_WHITELIST]:
             whitelist.append(mac)
         for mac in config[CONF_ENCRYPTORS]:
             whitelist.append(mac)
-        for mac in config[CONF_CUSTOM_NAMES]:
+        for mac in config[CONF_SENSOR_NAMES]:
             whitelist.append(mac)
     for i, mac in enumerate(whitelist):
         whitelist[i] = bytes.fromhex(reverse_mac(mac.replace(":", "")).lower())
@@ -818,7 +818,7 @@ class TemperatureSensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "t_" + self._sensor_name
+        self._unique_id = "t_" + mac
         self._device_state_attributes = {}
 
     @property
@@ -870,7 +870,7 @@ class HumiditySensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "h_" + self._sensor_name
+        self._unique_id = "h_" + mac
         self._device_state_attributes = {}
 
     @property
@@ -922,7 +922,7 @@ class MoistureSensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "m_" + self._sensor_name
+        self._unique_id = "m_" + mac
         self._device_state_attributes = {}
 
     @property
@@ -974,7 +974,7 @@ class ConductivitySensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "c_" + self._sensor_name
+        self._unique_id = "c_" + mac
         self._device_state_attributes = {}
 
     @property
@@ -1026,7 +1026,7 @@ class IlluminanceSensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "l_" + self._sensor_name
+        self._unique_id = "l_" + mac
         self._device_state_attributes = {}
 
     @property
@@ -1077,7 +1077,7 @@ class FormaldehydeSensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "f_" + self._sensor_name
+        self._unique_id = "f_" + mac
         self._device_state_attributes = {}
 
     @property
@@ -1127,7 +1127,7 @@ class BatterySensor(Entity):
         """Initialize the sensor."""
         self._state = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "batt_" + self._sensor_name
+        self._unique_id = "batt_" + mac
         self._device_state_attributes = {}
 
     @property
@@ -1178,7 +1178,7 @@ class ConsumableSensor(Entity):
         self._state = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "cn_" + self._sensor_name
+        self._unique_id = "cn_" + mac
         self._device_state_attributes = {}
 
     @property
@@ -1230,7 +1230,7 @@ class SwitchBinarySensor(BinarySensorEntity):
         self._swclass = None
         self._battery = None
         self._sensor_name = sensor_name(config, mac)
-        self._unique_id = "sw_" + self._sensor_name
+        self._unique_id = "sw_" + mac
         self._device_state_attributes = {}
 
     @property

--- a/info.md
+++ b/info.md
@@ -5,7 +5,7 @@
 
 # NB!: This is a Beta version!
 
-# Changes in 7.2 beta. 
+# Changes in 0.7.2 beta. 
 
 - Added option to configure sensor names in configuration.yaml, see the [sensor_names option](#sensor_names). Note that when you use or change this option, it will create new entities. This means that you will have to update your lovelace cards, automations and/or scripts that use the `entity_id`. Note that you can still rename sensors afterwards from the UI. After the change, you can manually delete the old entities from the Developer Tools.
 - Added the mac address to the attributes of the sensors

--- a/info.md
+++ b/info.md
@@ -3,12 +3,15 @@
 
 {% if prerelease %}
 
-### NB!: This is a Beta version!
-Changes in 7.2 beta. 
+# NB!: This is a Beta version!
+
+# Changes in 7.2 beta. 
 
 - Added option to configure sensor names in configuration.yaml, see the [sensor_names option](#sensor_names). Note that when you use or change this option, it will create new entities. This means that you will have to update your lovelace cards, automations and/or scripts that use the `entity_id`. Note that you can still rename sensors afterwards from the UI. After the change, you can manually delete the old entities from the Developer Tools.
 - Added the mac address to the attributes of the sensors
 - New sensors will be named according to a new convention: `mi_sensortype_mac` (e.g. `sensor.mi_temperature_A4C1382F86C`) (default) or `mi_sensortype_sensor_name` (e.g. `sensor.mi_temperature_livingroom`) (with [sensor_names option](#sensor_names)). Your current sensors with the short nameing (e.g. `mi_t_A4C1382F86C`) or manually modified names won't be renamed, unless you use the `sensor_names` option. 
+
+Note that this beta is not based on the 7.1 beta, which had some issues. It is a further developent from 0.6.13. 
 
 {% endif %}
 {% if installed or pending_update %}

--- a/info.md
+++ b/info.md
@@ -4,7 +4,11 @@
 {% if prerelease %}
 
 ### NB!: This is a Beta version!
-Beta version 7.1 is currently not working correctly with Home Assistant 0.113 and higher. Commonly observed issue is that Home Assistant hangs in the starting up process. If you observe this, please downgrade to stable version 6.11.
+Changes in 7.2 beta. 
+
+- Added option to configure sensor names in configuration.yaml, see the [sensor_names option](#sensor_names). Note that when you use or change this option, it will create new entities. This means that you will have to update your lovelace cards, automations and/or scripts that use the `entity_id`. Note that you can still rename sensors afterwards from the UI. After the change, you can manually delete the old entities from the Developer Tools.
+- Added the mac address to the attributes of the sensors
+- New sensors will be named according to a new convention: `mi_sensortype_mac` (e.g. `sensor.mi_temperature_A4C1382F86C`) (default) or `mi_sensortype_sensor_name` (e.g. `sensor.mi_temperature_livingroom`) (with [sensor_names option](#sensor_names)). Your current sensors with the short nameing (e.g. `mi_t_A4C1382F86C`) or manually modified names won't be renamed, unless you use the `sensor_names` option. 
 
 {% endif %}
 {% if installed or pending_update %}
@@ -177,6 +181,8 @@ sensor:
     batt_entities: False
     encryptors:
       'A4:C1:38:2F:86:6C': '217C568CF5D22808DA20181502D84C1B'
+    sensor_names:
+      'A4:C1:38:2F:86:6C': 'Livingroom'
     report_unknown: False
     whitelist: False
 ```
@@ -245,6 +251,18 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
          'A4:C1:38:D1:61:7D': 'C99D2313182473B38001086FEBF781BD'
    ```
 
+#### sensor_names
+
+   (dictionary)(Optional) Use this option to link a sensor name to the mac-address of the sensor. Using this option (or changing a name) will create new entities after restarting Home Assistant. These sensors are named with the following convention: `sensor.mi_sensortype_sensor_name` (e.g. `sensor.mi_temperature_livingroom`) in stead of the default `mi_sensortype_mac` (e.g. `sensor.mi_temperature_A4C1382F86C`). You will have to update your lovelace cards, automation and scripts after each change. Note that you can still override the entity_id from the UI. After the change, you can manually delete the old entities from the Developer Tools section. The old data won't be transfered to the new sensor. Default value: Empty
+
+   ```yaml
+   sensor:
+     - platform: mitemp_bt
+       sensor_names:
+         'A4:C1:38:2F:86:6C': 'Livingroom'
+         'A4:C1:38:D1:61:7D': 'Bedroom'
+   ```
+
 #### report_unknown
 
    (boolean)(Optional) This option is needed primarily for those who want to request an implementation of device support that is not in the list of [supported sensors](#supported-sensors). If you set this parameter to `True`, then the component will log all messages from unknown Xiaomi ecosystem devices to the Home Assitant log. **Attention!** Enabling this option can lead to huge output to the Home Assistant log, do not enable it if you do not need it! Details in the [FAQ](https://github.com/custom-components/sensor.mitemp_bt/blob/master/faq.md#my-sensor-from-the-xiaomi-ecosystem-is-not-in-the-list-of-supported-ones-how-to-request-implementation). Default value: False
@@ -261,9 +279,9 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
          - 'C4:FA:64:D1:61:7D'
    ```
 
-   data from sensors with other addresses will be ignored.
-   In addition, all addresses listed in the `encryptors` option will be automatically whitelisted.
-   If you have no sensors other than those listed in `encryptors`, then just set `whitelist` to `True`:
+   Data from sensors with other addresses will be ignored.
+   In addition, all addresses listed in the `encryptors` and `sensor_names` option will be automatically whitelisted.
+   If you have no sensors other than those listed in `encryptors` and/or `sensor_names`, then just set `whitelist` to `True`:
 
    ```yaml
    sensor:
@@ -275,7 +293,6 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
    ```
 
    Default value: False
-
 
 ## FREQUENTLY ASKED QUESTIONS
 


### PR DESCRIPTION
Update with the following new features, see also the request in #105

1. Added option to configure sensor names in configuration.yaml, see the sensor_names option. Note that when you use or change this option, it will create new entities. This means that you will have to update your lovelace cards, automations and/or scripts that use the entity_id. Note that you can still rename sensors afterwards from the UI. After the change, you can manually delete the old entities from the Developer Tools.
2. Added the mac address to the attributes of the sensors
3. New sensors will be named according to a new convention: mi_sensortype_mac (e.g. sensor.mi_temperature_A4C1382F86C) (default) or mi_sensortype_sensor_name (e.g. sensor.mi_temperature_livingroom) (with sensor_names option). Your current sensors with the short nameing (e.g. mi_t_A4C1382F86C) or manually modified names won't be renamed, unless you use the sensor_names option.