### PR TITLE
Use is_alive in favour of isAlive for Python 3.9 compatibility.

### DIFF
--- a/custom_components/mitemp_bt/sensor.py
+++ b/custom_components/mitemp_bt/sensor.py
@@ -408,9 +408,9 @@ class BLEScanner:
         """Stop HCIdump thread(s)."""
         result = True
         for dumpthread in self.dumpthreads:
-            if dumpthread.isAlive():
+            if dumpthread.is_alive():
                 dumpthread.join()
-                if dumpthread.isAlive():
+                if dumpthread.is_alive():
                     result = False
                     _LOGGER.error(
                         "Waiting for the HCIdump thread to finish took too long! (>10s)"


### PR DESCRIPTION
Fixes #122 