### PR TITLE
Fahrenheit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ sensor:
     batt_entities: False
     encryptors:
       'A4:C1:38:2F:86:6C': '217C568CF5D22808DA20181502D84C1B'
+    sensor_fahrenheit:
+      - 'C4:7C:8D:6B:4F:F3'
     sensor_names:
       'A4:C1:38:2F:86:6C': 'Livingroom'
     report_unknown: False
@@ -230,6 +232,18 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
        encryptors:
          'A4:C1:38:2F:86:6C': '217C568CF5D22808DA20181502D84C1B'
          'A4:C1:38:D1:61:7D': 'C99D2313182473B38001086FEBF781BD'
+   ```
+
+#### sensor_fahrenheit
+
+   (list)(Optional) Most sensors are sending temperature measurements in Celsius (°C), which is the default assumption for `mitemp_bt`. However, some sensors, like the `LYWSD03MMC` sensor with custom firmware will start sending temperature measurements in Fahrenheit (°F) after changing the display from Celsius to Fahrenheit. This means that you will have to tell mitemp_bt that it should expect Fahrenheit measurements for these specific sensors, by listing the MAC-addresses of these sensors.
+
+   ```yaml
+   sensor:
+     - platform: mitemp_bt
+       sensor_fahrenheit:
+         - '58:C1:38:2F:86:6C'
+         - 'C4:FA:64:D1:61:7D'
    ```
 
 #### sensor_names

--- a/custom_components/mitemp_bt/const.py
+++ b/custom_components/mitemp_bt/const.py
@@ -16,6 +16,7 @@ CONF_ENCRYPTORS = "encryptors"
 CONF_REPORT_UNKNOWN = "report_unknown"
 CONF_WHITELIST = "whitelist"
 CONF_SENSOR_NAMES = "sensor_names"
+CONF_SENSOR_FAHRENHEIT = "sensor_fahrenheit"
 
 # Default values for configuration options
 DEFAULT_ROUNDING = True
@@ -34,7 +35,7 @@ DEFAULT_WHITELIST = False
 
 # Sensor measurement limits to exclude erroneous spikes from the results
 CONF_TMIN = -40.0
-CONF_TMAX = 60.0
+CONF_TMAX = 160.0
 CONF_HMIN = 0.0
 CONF_HMAX = 99.9
 

--- a/custom_components/mitemp_bt/const.py
+++ b/custom_components/mitemp_bt/const.py
@@ -33,9 +33,9 @@ DEFAULT_WHITELIST = False
 
 """Fixed constants."""
 
-# Sensor measurement limits to exclude erroneous spikes from the results
+# Sensor measurement limits to exclude erroneous spikes from the results (temperature in °C)
 CONF_TMIN = -40.0
-CONF_TMAX = 160.0
+CONF_TMAX = 60.0
 CONF_HMIN = 0.0
 CONF_HMAX = 99.9
 

--- a/custom_components/mitemp_bt/sensor.py
+++ b/custom_components/mitemp_bt/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     CONDUCTIVITY,
     PERCENTAGE,
     TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
     ATTR_BATTERY_LEVEL,
     STATE_OFF, 
     STATE_ON,
@@ -54,6 +55,7 @@ from .const import (
     CONF_REPORT_UNKNOWN,
     CONF_WHITELIST,
     CONF_SENSOR_NAMES,
+    CONF_SENSOR_FAHRENHEIT,
     CONF_TMIN,
     CONF_TMAX,
     CONF_HMIN,
@@ -100,6 +102,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
             CONF_WHITELIST, default=DEFAULT_WHITELIST
         ): vol.Any(vol.All(cv.ensure_list, [cv.matches_regex(MAC_REGEX)]), cv.boolean),
         vol.Optional(CONF_SENSOR_NAMES, default={}): SENSOR_NAMES_LIST_SCHEMA,
+        vol.Optional(
+            CONF_SENSOR_FAHRENHEIT, default=[]
+        ): vol.All(cv.ensure_list, [cv.matches_regex(MAC_REGEX)]),
     }
 )
 
@@ -378,6 +383,15 @@ def sensor_name(config, mac):
         _LOGGER.debug("Name of sensor with mac adress %s is set to: %s", fmac, custom_name)
         return custom_name
     return mac
+
+
+def unit_of_measurement(config, mac):
+    """Set unit of measurement."""
+    fmac = ':'.join(mac[i:i+2] for i in range(0, len(mac), 2))
+    if fmac in config[CONF_SENSOR_FAHRENHEIT]:
+        _LOGGER.debug("Sensor with mac adress %s is using Fahrenheit as unit of measurement", fmac)
+        return TEMP_FAHRENHEIT
+    return TEMP_CELSIUS
 
 
 class BLEScanner:
@@ -874,7 +888,7 @@ class TemperatureSensor(MeasuringSensor):
         self._sensor_name = sensor_name(config, mac)
         self._name = "mi temperature {}".format(self._sensor_name)
         self._unique_id = "t_" + self._sensor_name
-        self._unit_of_measurement = TEMP_CELSIUS
+        self._unit_of_measurement = unit_of_measurement(config, mac)
         self._device_class = DEVICE_CLASS_TEMPERATURE
 
 

--- a/custom_components/mitemp_bt/sensor.py
+++ b/custom_components/mitemp_bt/sensor.py
@@ -72,16 +72,10 @@ _LOGGER = logging.getLogger(__name__)
 MAC_REGEX = "(?i)^(?:[0-9A-F]{2}[:]){5}(?:[0-9A-F]{2})$"
 AES128KEY_REGEX = "(?i)^[A-F0-9]{32}$"
 
-SENSOR_NAMES_LIST_SCHEMA = vol.Schema(
-    {
-        cv.matches_regex(MAC_REGEX): cv.string
-    }
-)
+SENSOR_NAMES_LIST_SCHEMA = vol.Schema({cv.matches_regex(MAC_REGEX): cv.string})
 
 ENCRYPTORS_LIST_SCHEMA = vol.Schema(
-    {
-        cv.matches_regex(MAC_REGEX): cv.matches_regex(AES128KEY_REGEX)
-    }
+    {cv.matches_regex(MAC_REGEX): cv.matches_regex(AES128KEY_REGEX)}
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -95,16 +89,20 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(
             CONF_HCI_INTERFACE, default=[DEFAULT_HCI_INTERFACE]
         ): vol.All(cv.ensure_list, [cv.positive_int]),
-        vol.Optional(CONF_BATT_ENTITIES, default=DEFAULT_BATT_ENTITIES): cv.boolean,
+        vol.Optional(
+            CONF_BATT_ENTITIES, default=DEFAULT_BATT_ENTITIES
+        ): cv.boolean,
         vol.Optional(CONF_ENCRYPTORS, default={}): ENCRYPTORS_LIST_SCHEMA,
-        vol.Optional(CONF_REPORT_UNKNOWN, default=DEFAULT_REPORT_UNKNOWN): cv.boolean,
         vol.Optional(
-            CONF_WHITELIST, default=DEFAULT_WHITELIST
-        ): vol.Any(vol.All(cv.ensure_list, [cv.matches_regex(MAC_REGEX)]), cv.boolean),
+            CONF_REPORT_UNKNOWN, default=DEFAULT_REPORT_UNKNOWN
+        ): cv.boolean,
+        vol.Optional(CONF_WHITELIST, default=DEFAULT_WHITELIST): vol.Any(
+            vol.All(cv.ensure_list, [cv.matches_regex(MAC_REGEX)]), cv.boolean
+        ),
         vol.Optional(CONF_SENSOR_NAMES, default={}): SENSOR_NAMES_LIST_SCHEMA,
-        vol.Optional(
-            CONF_SENSOR_FAHRENHEIT, default=[]
-        ): vol.All(cv.ensure_list, [cv.matches_regex(MAC_REGEX)]),
+        vol.Optional(CONF_SENSOR_FAHRENHEIT, default=[]): vol.All(
+            cv.ensure_list, [cv.matches_regex(MAC_REGEX)]
+        ),
     }
 )
 
@@ -380,18 +378,32 @@ def sensor_name(config, mac):
     fmac = ':'.join(mac[i:i+2] for i in range(0, len(mac), 2))
     if fmac in config[CONF_SENSOR_NAMES]:
         custom_name = config[CONF_SENSOR_NAMES].get(fmac)
-        _LOGGER.debug("Name of sensor with mac adress %s is set to: %s", fmac, custom_name)
+        _LOGGER.debug(
+            "Name of sensor with mac adress %s is set to: %s", fmac, custom_name
+        )
         return custom_name
     return mac
 
 
 def unit_of_measurement(config, mac):
-    """Set unit of measurement."""
+    """Set unit of measurement to °C or °F."""
     fmac = ':'.join(mac[i:i+2] for i in range(0, len(mac), 2))
     if fmac in config[CONF_SENSOR_FAHRENHEIT]:
-        _LOGGER.debug("Sensor with mac adress %s is using Fahrenheit as unit of measurement", fmac)
+        _LOGGER.debug(
+            "Sensor with mac address %s is using Fahrenheit as unit of measurement",
+            fmac,
+        )
         return TEMP_FAHRENHEIT
     return TEMP_CELSIUS
+
+
+def temperature_limit(config, mac, temp):
+    """Set limits for temperature measurement in °C or °F."""
+    fmac = ':'.join(mac[i:i+2] for i in range(0, len(mac), 2))
+    if fmac in config[CONF_SENSOR_FAHRENHEIT]:
+        temp_fahrenheit = temp * 9 / 5 + 32
+        return temp_fahrenheit
+    return temp
 
 
 class BLEScanner:
@@ -497,7 +509,12 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     sleep(1)
 
     def calc_update_state(
-        entity_to_update, sensor_mac, config, measurements_list, stype=None, fdec = 0
+        entity_to_update,
+        sensor_mac,
+        config,
+        measurements_list,
+        stype=None,
+        fdec=0,
     ):
         """Averages according to options and updates the entity state."""
         textattr = ""
@@ -514,12 +531,8 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             measurements = measurements_list
         try:
             if config[CONF_ROUNDING]:
-                state_median = round(
-                    sts.median(measurements), rdecimals
-                )
-                state_mean = round(
-                    sts.mean(measurements), rdecimals
-                )
+                state_median = round(sts.median(measurements), rdecimals)
+                state_mean = round(sts.mean(measurements), rdecimals)
             else:
                 state_median = sts.median(measurements)
                 state_mean = sts.mean(measurements)
@@ -529,13 +542,15 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             else:
                 textattr = "last mean of"
                 setattr(entity_to_update, "_state", state_mean)
-            getattr(entity_to_update, "_device_state_attributes")[textattr] = len(
-                measurements
-            )
+            getattr(entity_to_update, "_device_state_attributes")[
+                textattr
+            ] = len(measurements)
             getattr(entity_to_update, "_device_state_attributes")[
                 "median"
             ] = state_median
-            getattr(entity_to_update, "_device_state_attributes")["mean"] = state_mean
+            getattr(entity_to_update, "_device_state_attributes")[
+                "mean"
+            ] = state_mean
             entity_to_update.schedule_update_ha_state()
             success = True
         except (AttributeError, AssertionError):
@@ -591,7 +606,11 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 lpacket(data["mac"], packet)
                 # store found readings per device
                 if "temperature" in data:
-                    if CONF_TMAX >= data["temperature"] >= CONF_TMIN:
+                    if (
+                        temperature_limit(config, data["mac"], CONF_TMAX)
+                        >= data["temperature"]
+                        >= temperature_limit(config, data["mac"], CONF_TMIN)
+                    ):
                         if data["mac"] not in temp_m_data:
                             temp_m_data[data["mac"]] = []
                         temp_m_data[data["mac"]].append(data["temperature"])
@@ -610,7 +629,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                         macs[data["mac"]] = data["mac"]
                     elif log_spikes:
                         _LOGGER.error(
-                            "Humidity spike: %s (%s)", data["humidity"], data["mac"],
+                            "Humidity spike: %s (%s)",
+                            data["humidity"],
+                            data["mac"],
                         )
                 if "conductivity" in data:
                     if data["mac"] not in cond_m_data:

--- a/info.md
+++ b/info.md
@@ -5,15 +5,9 @@
 
 # NB!: This is a Beta version!
 
-# Changes in 0.7.4 beta. 
+# Changes in 0.7.7 beta. 
 
-This time, only some code optimization, reducing the number of lines of python code with about 20%.
-
-- Adding a MeasuringSensor class which is used for all measuring sensors, to shorten the python code (won't affect users)
-- Adding device_class Illuminance to illuminance sensors (will change the icon to default Home Asssistant icon)
-- Using default unit of measurements from Home Assistant constants (won't affect users)
-
-Changes were based on a small part of the changes as proposed in beta 0.7.1 by @Magalex2x14, further developed by me (@Ernst79).
+Add support for sensors that send their temperature data in Fahrenheit. The LYWSD03MMC with custom firmware will send temperature data in Fahrenheit after changing the display to Fahrenheit. Use the [sensor_fahrenheit](#sensor_fahrenheit) option for these sensors to get the correct data in Home Asssitant.
 
 {% endif %}
 {% if installed or pending_update %}

--- a/info.md
+++ b/info.md
@@ -18,9 +18,9 @@ Changes were based on a small part of the changes as proposed in beta 0.7.1 by @
 {% endif %}
 {% if installed or pending_update %}
 
-# Changes in 0.7.6
+# Changes in 0.7.7
 
-Added battery level support for LYWSD02 sensor. Note that battery level is only supported for LYWSD02 sensors with firmware 1.1.2_00085 or later.
+Add support for sensors that send their temperature data in Fahrenheit. The LYWSD03MMC with custom firmware will send temperature data in Fahrenheit after changing the display to Fahrenheit. Use the [sensor_fahrenheit](#sensor_fahrenheit) option for these sensors to get the correct data in Home Asssitant.
 
 {% endif %}
 
@@ -186,6 +186,8 @@ sensor:
     batt_entities: False
     encryptors:
       'A4:C1:38:2F:86:6C': '217C568CF5D22808DA20181502D84C1B'
+     sensor_fahrenheit:
+       - '58:C1:38:2F:86:6C'
     sensor_names:
       'A4:C1:38:2F:86:6C': 'Livingroom'
     report_unknown: False
@@ -254,6 +256,18 @@ Note: The encryptors parameter is only needed for sensors, for which it is [poin
        encryptors:
          'A4:C1:38:2F:86:6C': '217C568CF5D22808DA20181502D84C1B'
          'A4:C1:38:D1:61:7D': 'C99D2313182473B38001086FEBF781BD'
+   ```
+
+#### sensor_fahrenheit
+
+   (list)(Optional) Most sensors are sending temperature measurements in Celsius (°C), which is the default assumption for `mitemp_bt`. However, some sensors, like the `LYWSD03MMC` sensor with custom firmware will start sending temperature measurements in Fahrenheit (°F) after changing the display from Celsius to Fahrenheit. This means that you will have to tell mitemp_bt that it should expect Fahrenheit measurements for these specific sensors, by listing the MAC-addresses of these sensors.
+
+   ```yaml
+   sensor:
+     - platform: mitemp_bt
+       sensor_fahrenheit:
+         - '58:C1:38:2F:86:6C'
+         - 'C4:FA:64:D1:61:7D'
    ```
 
 #### sensor_names


### PR DESCRIPTION
This PR contains the following

1. adds support for sensors that send their temperature data in Fahrenheit. The LYWSD03MMC with custom firmware will send temperature data in Fahrenheit after changing the display to Fahrenheit. Added the configuration parameter `sensor_fahrenheit` for these sensors to get the correct data in Home Asssitant. Fix #132 
2. some `black` code formatting fixes