### PR TITLE
case insensitive configuration

### DIFF
--- a/custom_components/mitemp_bt/sensor.py
+++ b/custom_components/mitemp_bt/sensor.py
@@ -373,24 +373,31 @@ def parse_raw_message(data, aeskeyslist,  whitelist, report_unknown=False):
     return result
 
 
-def sensor_name(config, mac):
+def sensor_name(config, mac, sensor_type):
     """Set sensor name."""
-    fmac = ':'.join(mac[i:i+2] for i in range(0, len(mac), 2))
-    if fmac in config[CONF_SENSOR_NAMES]:
-        custom_name = config[CONF_SENSOR_NAMES].get(fmac)
+    fmac = ":".join(mac[i : i + 2] for i in range(0, len(mac), 2))
+    sensor_names_dict = {
+        k.upper(): v for k, v in config[CONF_SENSOR_NAMES].items()
+    }
+    if fmac in sensor_names_dict:
+        custom_name = sensor_names_dict.get(fmac)
         _LOGGER.debug(
-            "Name of sensor with mac adress %s is set to: %s", fmac, custom_name
+            "Name of %s sensor with mac adress %s is set to: %s",
+            sensor_type,
+            fmac,
+            custom_name,
         )
         return custom_name
     return mac
-
+    
 
 def unit_of_measurement(config, mac):
     """Set unit of measurement to °C or °F."""
     fmac = ':'.join(mac[i:i+2] for i in range(0, len(mac), 2))
-    if fmac in config[CONF_SENSOR_FAHRENHEIT]:
+    sensor_fahrenheit_list = [x.upper() for x in config[CONF_SENSOR_FAHRENHEIT]]
+    if fmac in sensor_fahrenheit_list:
         _LOGGER.debug(
-            "Sensor with mac address %s is using Fahrenheit as unit of measurement",
+            "Temperature sensor with mac address %s is set to receive data in Fahrenheit",
             fmac,
         )
         return TEMP_FAHRENHEIT
@@ -400,7 +407,8 @@ def unit_of_measurement(config, mac):
 def temperature_limit(config, mac, temp):
     """Set limits for temperature measurement in °C or °F."""
     fmac = ':'.join(mac[i:i+2] for i in range(0, len(mac), 2))
-    if fmac in config[CONF_SENSOR_FAHRENHEIT]:
+    sensor_fahrenheit_list = [x.upper() for x in config[CONF_SENSOR_FAHRENHEIT]]
+    if fmac in sensor_fahrenheit_list:
         temp_fahrenheit = temp * 9 / 5 + 32
         return temp_fahrenheit
     return temp
@@ -505,6 +513,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     for i, mac in enumerate(whitelist):
         whitelist[i] = bytes.fromhex(reverse_mac(mac.replace(":", "")).lower())
     _LOGGER.debug("%s whitelist item(s) loaded.", len(whitelist))
+    _LOGGER.debug("whitelist: %s", whitelist)
     lpacket.cntr = {}
     sleep(1)
 
@@ -906,7 +915,7 @@ class TemperatureSensor(MeasuringSensor):
     def __init__(self, config, mac):
         "Initialize the sensor."""
         super().__init__(config, mac)
-        self._sensor_name = sensor_name(config, mac)
+        self._sensor_name = sensor_name(config, mac, "temperature")
         self._name = "mi temperature {}".format(self._sensor_name)
         self._unique_id = "t_" + self._sensor_name
         self._unit_of_measurement = unit_of_measurement(config, mac)
@@ -919,7 +928,7 @@ class HumiditySensor(MeasuringSensor):
     def __init__(self, config, mac):
         """Initialize the sensor."""
         super().__init__(config, mac)
-        self._sensor_name = sensor_name(config, mac)
+        self._sensor_name = sensor_name(config, mac, "humidity")
         self._name = "mi humidity {}".format(self._sensor_name)
         self._unique_id = "h_" + self._sensor_name
         self._unit_of_measurement = PERCENTAGE 
@@ -932,7 +941,7 @@ class MoistureSensor(MeasuringSensor):
     def __init__(self, config, mac):
         """Initialize the sensor."""
         super().__init__(config, mac)
-        self._sensor_name = sensor_name(config, mac)
+        self._sensor_name = sensor_name(config, mac, "moisture")
         self._name = "mi moisture {}".format(self._sensor_name)
         self._unique_id = "m_" + self._sensor_name
         self._unit_of_measurement = PERCENTAGE 
@@ -945,7 +954,7 @@ class ConductivitySensor(MeasuringSensor):
     def __init__(self, config, mac):
         """Initialize the sensor."""
         super().__init__(config, mac)
-        self._sensor_name = sensor_name(config, mac)
+        self._sensor_name = sensor_name(config, mac, "conductivity")
         self._name = "mi conductivity {}".format(self._sensor_name)
         self._unique_id = "c_" + self._sensor_name
         self._unit_of_measurement = CONDUCTIVITY
@@ -963,7 +972,7 @@ class IlluminanceSensor(MeasuringSensor):
     def __init__(self, config, mac):
         """Initialize the sensor."""
         super().__init__(config, mac)
-        self._sensor_name = sensor_name(config, mac)
+        self._sensor_name = sensor_name(config, mac, "illuminance")
         self._name = "mi llluminance {}".format(self._sensor_name)
         self._unique_id = "l_" + self._sensor_name
         self._unit_of_measurement = "lx"
@@ -976,7 +985,7 @@ class FormaldehydeSensor(MeasuringSensor):
     def __init__(self, config, mac):
         """Initialize the sensor."""
         super().__init__(config, mac)
-        self._sensor_name = sensor_name(config, mac)
+        self._sensor_name = sensor_name(config, mac, "formaldehyde")
         self._name = "mi formaldehyde {}".format(self._sensor_name)
         self._unique_id = "f_" + self._sensor_name
         self._unit_of_measurement = "mg/m³"
@@ -994,7 +1003,7 @@ class BatterySensor(MeasuringSensor):
     def __init__(self, config, mac):
         """Initialize the sensor."""
         super().__init__(config, mac)
-        self._sensor_name = sensor_name(config, mac)
+        self._sensor_name = sensor_name(config, mac, "battery")
         self._name = "mi battery {}".format(self._sensor_name)
         self._unique_id = "batt__" + self._sensor_name
         self._unit_of_measurement = PERCENTAGE
@@ -1007,7 +1016,7 @@ class ConsumableSensor(MeasuringSensor):
     def __init__(self, config, mac):
         """Initialize the sensor."""
         super().__init__(config, mac)
-        self._sensor_name = sensor_name(config, mac)
+        self._sensor_name = sensor_name(config, mac, "consumbable")
         self._name = "mi consumable {}".format(self._sensor_name)
         self._unique_id = "cn__" + self._sensor_name
         self._unit_of_measurement = PERCENTAGE
@@ -1024,7 +1033,7 @@ class SwitchBinarySensor(BinarySensorEntity):
 
     def __init__(self, config, mac):
         """Initialize the sensor."""
-        self._sensor_name = sensor_name(config, mac)
+        self._sensor_name = sensor_name(config, mac, "switch")
         self._name = "mi switch {}".format(self._sensor_name)
         self._state = None
         self._unique_id = "sw_" + sensor_name(config, mac)

--- a/custom_components/mitemp_bt/sensor.py
+++ b/custom_components/mitemp_bt/sensor.py
@@ -1036,7 +1036,7 @@ class SwitchBinarySensor(BinarySensorEntity):
         self._sensor_name = sensor_name(config, mac, "switch")
         self._name = "mi switch {}".format(self._sensor_name)
         self._state = None
-        self._unique_id = "sw_" + sensor_name(config, mac)
+        self._unique_id = "sw_" + self._sensor_name
         self._device_state_attributes = {}
         self._device_class = None
 


### PR DESCRIPTION
Fix for #136 

- This PR makes the MAC address of the `sensor_names` and `sensor_fahrenheit` options case insensitive. 
- Small improvement in the debugging messages when using `sensor_names`